### PR TITLE
ENG-4460 Removing protobuf dependency 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -180,7 +180,6 @@
         <jaxb-runtime.version>2.3.4</jaxb-runtime.version>
         <jakarta.annotation-api.version>1.3.5</jakarta.annotation-api.version>
         <keycloak-admin-client.version>15.1.1</keycloak-admin-client.version>
-        <protobuf-java.version>3.19.2</protobuf-java.version>
         <xercesImpl.version>2.12.2</xercesImpl.version>
         <junrar.version>7.4.1</junrar.version>
         <netty-common.version>4.1.77.Final</netty-common.version>
@@ -1536,11 +1535,6 @@
                 <groupId>org.keycloak</groupId>
                 <artifactId>keycloak-admin-client</artifactId>
                 <version>${keycloak-admin-client.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.google.protobuf</groupId>
-                <artifactId>protobuf-java</artifactId>
-                <version>${protobuf-java.version}</version>
             </dependency>
             <dependency>
                 <groupId>xerces</groupId>


### PR DESCRIPTION
This dependency on com.google.protobuf:protobuf-java version 3.19.2 was added in order to fix a tika-parser vulnerability ([CVE-2021-22569](https://security.snyk.io/vuln/SNYK-RUBY-GOOGLEPROTOBUF-2331705)) as part of ENG-3206. The tika-parser vulnerability has since been fixed through a version update, and the protobuf library in this version has three additional vulnerabilities (CVE-2022-3509, CVE-2022-3510, and CVE-2022-3171) that have not been addressed. As a result, it is safe to remove this dependency in order to avoid known vulnerabilities and keep dependencies up-to-date.