### PR TITLE
ENG-4738 add disableContentMenu property

### DIFF
--- a/engine/src/main/java/org/entando/entando/aps/system/services/userpreferences/UserPreferences.java
+++ b/engine/src/main/java/org/entando/entando/aps/system/services/userpreferences/UserPreferences.java
@@ -21,7 +21,7 @@ import javax.xml.bind.annotation.XmlType;
 @XmlRootElement(name = "userPreferences")
 @XmlType(propOrder = {"username", "wizard", "loadOnPageSelect", "translationWarning", "defaultPageOwnerGroup",
 		"defaultPageJoinGroups", "defaultContentOwnerGroup", "defaultContentJoinGroups", "defaultWidgetOwnerGroup",
-		"defaultWidgetJoinGroups"})
+		"defaultWidgetJoinGroups", "disableContentMenu"})
 public class UserPreferences implements Serializable {
 
 	private String username;
@@ -34,6 +34,7 @@ public class UserPreferences implements Serializable {
 	private String defaultContentJoinGroups;
 	private String defaultWidgetOwnerGroup;
 	private String defaultWidgetJoinGroups;
+	private boolean disableContentMenu;
 
 	@XmlElement(name = "username", required = true)
 	public String getUsername() {
@@ -125,6 +126,15 @@ public class UserPreferences implements Serializable {
 		this.defaultWidgetJoinGroups = defaultWidgetJoinGroups;
 	}
 
+	@XmlElement(name = "disableContentMenu")
+	public boolean getDisableContentMenu() {
+		return disableContentMenu;
+	}
+
+	public void setDisableContentMenu(boolean disableContentMenu) {
+		this.disableContentMenu = disableContentMenu;
+	}
+
 	@Override
 	public String toString() {
 		return "UserPreferences{" +
@@ -138,6 +148,7 @@ public class UserPreferences implements Serializable {
 				", defaultContentJoinGroups='" + defaultContentJoinGroups + '\'' +
 				", defaultWidgetOwnerGroup='" + defaultWidgetOwnerGroup + '\'' +
 				", defaultWidgetJoinGroups='" + defaultWidgetJoinGroups + '\'' +
+				", disableContentMenu='" + disableContentMenu +
 				'}';
 	}
 }

--- a/engine/src/main/java/org/entando/entando/aps/system/services/userpreferences/UserPreferencesDAO.java
+++ b/engine/src/main/java/org/entando/entando/aps/system/services/userpreferences/UserPreferencesDAO.java
@@ -23,25 +23,25 @@ import org.entando.entando.ent.util.EntLogging.EntLogFactory;
 import org.entando.entando.ent.util.EntLogging.EntLogger;
 
 public class UserPreferencesDAO extends AbstractDAO implements IUserPreferencesDAO {
-	
+
 	private static final EntLogger _logger =  EntLogFactory.getSanitizedLogger(UserPreferencesDAO.class);
 
 	private static final String LOAD_USER_PREFERENCES =
 			"SELECT wizard, loadonpageselect, translationwarning, defaultpageownergroup, defaultpagejoingroups, "
 					+ "defaultcontentownergroup, defaultcontentjoingroups, defaultwidgetownergroup, "
-					+ "defaultwidgetjoingroups FROM userpreferences WHERE username = ? ";
+					+ "defaultwidgetjoingroups, disableContentMenu FROM userpreferences WHERE username = ? ";
 
 	private static final String ADD_USER_PREFERENCES =
 			"INSERT INTO userpreferences (username, wizard, loadonpageselect, translationwarning, "
 					+ "defaultpageownergroup, defaultpagejoingroups, defaultcontentownergroup, "
-					+ "defaultcontentjoingroups, defaultwidgetownergroup, defaultwidgetjoingroups) VALUES ( ? , ? ,"
-					+ " ? , ? , ? , ?, ?, ?, ?, ? )";
+					+ "defaultcontentjoingroups, defaultwidgetownergroup, defaultwidgetjoingroups, disableContentMenu) "
+					+ "VALUES ( ? , ? , ? , ? , ? , ? , ? , ? , ? , ? , ? )";
 
 	private static final String UPDATE_USER_PREFERENCES =
 			"UPDATE userpreferences SET wizard = ? , loadonpageselect = ? , translationwarning = ? , "
 					+ "defaultpageownergroup = ? , defaultpagejoingroups = ? , defaultcontentownergroup = ? , "
-					+ "defaultcontentjoingroups = ? , defaultwidgetownergroup = ?, defaultwidgetjoingroups = ? WHERE "
-					+ "username = ? ";
+					+ "defaultcontentjoingroups = ? , defaultwidgetownergroup = ?, defaultwidgetjoingroups = ? , "
+					+ "disableContentMenu = ? WHERE username = ? ";
 
 	private static final String DELETE_USER_PREFERENCES =
 			"DELETE FROM userpreferences WHERE username = ? ";
@@ -69,6 +69,7 @@ public class UserPreferencesDAO extends AbstractDAO implements IUserPreferencesD
 				response.setDefaultContentJoinGroups(res.getString(7));
 				response.setDefaultWidgetOwnerGroup(res.getString(8));
 				response.setDefaultWidgetJoinGroups(res.getString(9));
+				response.setDisableContentMenu(1 == res.getInt(10));
 			}
 		} catch (SQLException e) {
 			_logger.error("Error loading user preferences for user {}", username,  e);
@@ -97,6 +98,7 @@ public class UserPreferencesDAO extends AbstractDAO implements IUserPreferencesD
 			stat.setString(8, userPreferences.getDefaultContentJoinGroups());
 			stat.setString(9, userPreferences.getDefaultWidgetOwnerGroup());
 			stat.setString(10, userPreferences.getDefaultWidgetJoinGroups());
+			stat.setInt(11, userPreferences.getDisableContentMenu() ? 1 : 0);
 			stat.executeUpdate();
 			conn.commit();
 		} catch (SQLException e) {
@@ -125,7 +127,8 @@ public class UserPreferencesDAO extends AbstractDAO implements IUserPreferencesD
 			stat.setString(7, userPreferences.getDefaultContentJoinGroups());
 			stat.setString(8, userPreferences.getDefaultWidgetOwnerGroup());
 			stat.setString(9, userPreferences.getDefaultWidgetJoinGroups());
-			stat.setString(10, userPreferences.getUsername());
+			stat.setInt(10, userPreferences.getDisableContentMenu() ? 1 : 0);
+			stat.setString(11, userPreferences.getUsername());
 			stat.executeUpdate();
 			conn.commit();
 		} catch (SQLException e) {

--- a/engine/src/main/java/org/entando/entando/aps/system/services/userpreferences/UserPreferencesService.java
+++ b/engine/src/main/java/org/entando/entando/aps/system/services/userpreferences/UserPreferencesService.java
@@ -92,6 +92,9 @@ public class UserPreferencesService implements IUserPreferencesService {
                     }
                     userPreferences.setDefaultWidgetJoinGroups(sb.toString());
                 }
+                if (request.getDisableContentMenu() != null) {
+                    userPreferences.setDisableContentMenu(request.getDisableContentMenu());
+                }
                 userPreferencesManager.updateUserPreferences(userPreferences);
                 return new UserPreferencesDto(userPreferencesManager.getUserPreferences(username));
             } else {

--- a/engine/src/main/java/org/entando/entando/web/userpreferences/model/UserPreferencesDto.java
+++ b/engine/src/main/java/org/entando/entando/web/userpreferences/model/UserPreferencesDto.java
@@ -31,11 +31,13 @@ public class UserPreferencesDto {
     private List<String> defaultContentJoinGroups;
     private String defaultWidgetOwnerGroup;
     private List<String> defaultWidgetJoinGroups;
+    private Boolean disableContentMenu;
 
     public UserPreferencesDto(UserPreferences userPreferences) {
         wizard = userPreferences.isWizard();
         loadOnPageSelect = userPreferences.isLoadOnPageSelect();
         translationWarning = userPreferences.isTranslationWarning();
+        disableContentMenu = userPreferences.getDisableContentMenu();
 
         defaultPageOwnerGroup = userPreferences.getDefaultPageOwnerGroup();
         String defaultJoinPageGroupsString = userPreferences.getDefaultPageJoinGroups();
@@ -149,6 +151,14 @@ public class UserPreferencesDto {
         this.defaultWidgetJoinGroups = defaultWidgetJoinGroups;
     }
 
+    public Boolean getDisableContentMenu() {
+        return disableContentMenu;
+    }
+
+    public void setDisableContentMenu(Boolean disableContentMenu) {
+        this.disableContentMenu = disableContentMenu;
+    }
+
     @Override
     public String toString() {
         return "UserPreferencesDto{" +
@@ -161,6 +171,7 @@ public class UserPreferencesDto {
                 ", defaultContentJoinGroups=" + defaultContentJoinGroups +
                 ", defaultWidgetOwnerGroup='" + defaultWidgetOwnerGroup + '\'' +
                 ", defaultWidgetJoinGroups=" + defaultWidgetJoinGroups +
+                ", disableContentMenu=" + disableContentMenu +
                 '}';
     }
 }

--- a/engine/src/main/java/org/entando/entando/web/userpreferences/model/UserPreferencesDto.java
+++ b/engine/src/main/java/org/entando/entando/web/userpreferences/model/UserPreferencesDto.java
@@ -17,11 +17,14 @@ import static org.entando.entando.aps.system.services.userpreferences.UserPrefer
 
 import java.util.ArrayList;
 import java.util.List;
+import lombok.Getter;
+import lombok.Setter;
 import org.apache.commons.lang3.StringUtils;
 import org.entando.entando.aps.system.services.userpreferences.UserPreferences;
 
+@Getter@Setter
 public class UserPreferencesDto {
-
+    
     private Boolean wizard;
     private Boolean loadOnPageSelect;
     private Boolean translationWarning;
@@ -77,86 +80,6 @@ public class UserPreferencesDto {
                 }
             }
         }
-    }
-
-    public Boolean getWizard() {
-        return wizard;
-    }
-
-    public void setWizard(Boolean wizard) {
-        this.wizard = wizard;
-    }
-
-    public Boolean getLoadOnPageSelect() {
-        return loadOnPageSelect;
-    }
-
-    public void setLoadOnPageSelect(Boolean loadOnPageSelect) {
-        this.loadOnPageSelect = loadOnPageSelect;
-    }
-
-    public Boolean getTranslationWarning() {
-        return translationWarning;
-    }
-
-    public void setTranslationWarning(Boolean translationWarning) {
-        this.translationWarning = translationWarning;
-    }
-
-    public String getDefaultPageOwnerGroup() {
-        return defaultPageOwnerGroup;
-    }
-
-    public void setDefaultPageOwnerGroup(String defaultPageOwnerGroup) {
-        this.defaultPageOwnerGroup = defaultPageOwnerGroup;
-    }
-
-    public List<String> getDefaultPageJoinGroups() {
-        return defaultPageJoinGroups;
-    }
-
-    public void setDefaultPageJoinGroups(List<String> defaultPageJoinGroups) {
-        this.defaultPageJoinGroups = defaultPageJoinGroups;
-    }
-
-    public String getDefaultContentOwnerGroup() {
-        return defaultContentOwnerGroup;
-    }
-
-    public void setDefaultContentOwnerGroup(String defaultContentOwnerGroup) {
-        this.defaultContentOwnerGroup = defaultContentOwnerGroup;
-    }
-
-    public List<String> getDefaultContentJoinGroups() {
-        return defaultContentJoinGroups;
-    }
-
-    public void setDefaultContentJoinGroups(List<String> defaultContentJoinGroups) {
-        this.defaultContentJoinGroups = defaultContentJoinGroups;
-    }
-
-    public String getDefaultWidgetOwnerGroup() {
-        return defaultWidgetOwnerGroup;
-    }
-
-    public void setDefaultWidgetOwnerGroup(String defaultWidgetOwnerGroup) {
-        this.defaultWidgetOwnerGroup = defaultWidgetOwnerGroup;
-    }
-
-    public List<String> getDefaultWidgetJoinGroups() {
-        return defaultWidgetJoinGroups;
-    }
-
-    public void setDefaultWidgetJoinGroups(List<String> defaultWidgetJoinGroups) {
-        this.defaultWidgetJoinGroups = defaultWidgetJoinGroups;
-    }
-
-    public Boolean getDisableContentMenu() {
-        return disableContentMenu;
-    }
-
-    public void setDisableContentMenu(Boolean disableContentMenu) {
-        this.disableContentMenu = disableContentMenu;
     }
 
     @Override

--- a/engine/src/main/java/org/entando/entando/web/userpreferences/model/UserPreferencesRequest.java
+++ b/engine/src/main/java/org/entando/entando/web/userpreferences/model/UserPreferencesRequest.java
@@ -14,7 +14,10 @@
 package org.entando.entando.web.userpreferences.model;
 
 import java.util.List;
+import lombok.Getter;
+import lombok.Setter;
 
+@Getter@Setter
 public class UserPreferencesRequest {
 
     private Boolean wizard;
@@ -27,86 +30,6 @@ public class UserPreferencesRequest {
     private String defaultWidgetOwnerGroup;
     private List<String> defaultWidgetJoinGroups;
     private Boolean disableContentMenu;
-
-    public Boolean getWizard() {
-        return wizard;
-    }
-
-    public void setWizard(Boolean wizard) {
-        this.wizard = wizard;
-    }
-
-    public Boolean getLoadOnPageSelect() {
-        return loadOnPageSelect;
-    }
-
-    public void setLoadOnPageSelect(Boolean loadOnPageSelect) {
-        this.loadOnPageSelect = loadOnPageSelect;
-    }
-
-    public Boolean getTranslationWarning() {
-        return translationWarning;
-    }
-
-    public void setTranslationWarning(Boolean translationWarning) {
-        this.translationWarning = translationWarning;
-    }
-
-    public String getDefaultPageOwnerGroup() {
-        return defaultPageOwnerGroup;
-    }
-
-    public void setDefaultPageOwnerGroup(String defaultPageOwnerGroup) {
-        this.defaultPageOwnerGroup = defaultPageOwnerGroup;
-    }
-
-    public List<String> getDefaultPageJoinGroups() {
-        return defaultPageJoinGroups;
-    }
-
-    public void setDefaultPageJoinGroups(List<String> defaultPageJoinGroups) {
-        this.defaultPageJoinGroups = defaultPageJoinGroups;
-    }
-
-    public String getDefaultContentOwnerGroup() {
-        return defaultContentOwnerGroup;
-    }
-
-    public void setDefaultContentOwnerGroup(String defaultContentOwnerGroup) {
-        this.defaultContentOwnerGroup = defaultContentOwnerGroup;
-    }
-
-    public List<String> getDefaultContentJoinGroups() {
-        return defaultContentJoinGroups;
-    }
-
-    public void setDefaultContentJoinGroups(List<String> defaultContentJoinGroups) {
-        this.defaultContentJoinGroups = defaultContentJoinGroups;
-    }
-
-    public String getDefaultWidgetOwnerGroup() {
-        return defaultWidgetOwnerGroup;
-    }
-
-    public void setDefaultWidgetOwnerGroup(String defaultWidgetOwnerGroup) {
-        this.defaultWidgetOwnerGroup = defaultWidgetOwnerGroup;
-    }
-
-    public List<String> getDefaultWidgetJoinGroups() {
-        return defaultWidgetJoinGroups;
-    }
-
-    public void setDefaultWidgetJoinGroups(List<String> defaultWidgetJoinGroups) {
-        this.defaultWidgetJoinGroups = defaultWidgetJoinGroups;
-    }
-
-    public Boolean getDisableContentMenu() {
-        return disableContentMenu;
-    }
-
-    public void setDisableContentMenu(Boolean disableContentMenu) {
-        this.disableContentMenu = disableContentMenu;
-    }
 
     @Override
     public String toString() {

--- a/engine/src/main/java/org/entando/entando/web/userpreferences/model/UserPreferencesRequest.java
+++ b/engine/src/main/java/org/entando/entando/web/userpreferences/model/UserPreferencesRequest.java
@@ -26,6 +26,7 @@ public class UserPreferencesRequest {
     private List<String> defaultContentJoinGroups;
     private String defaultWidgetOwnerGroup;
     private List<String> defaultWidgetJoinGroups;
+    private Boolean disableContentMenu;
 
     public Boolean getWizard() {
         return wizard;
@@ -99,6 +100,14 @@ public class UserPreferencesRequest {
         this.defaultWidgetJoinGroups = defaultWidgetJoinGroups;
     }
 
+    public Boolean getDisableContentMenu() {
+        return disableContentMenu;
+    }
+
+    public void setDisableContentMenu(Boolean disableContentMenu) {
+        this.disableContentMenu = disableContentMenu;
+    }
+
     @Override
     public String toString() {
         return "UserPreferencesRequest{" +
@@ -111,6 +120,7 @@ public class UserPreferencesRequest {
                 ", defaultContentJoinGroups=" + defaultContentJoinGroups +
                 ", defaultWidgetOwnerGroup='" + defaultWidgetOwnerGroup + '\'' +
                 ", defaultWidgetJoinGroups=" + defaultWidgetJoinGroups +
+                ", disableContentMenu=" + disableContentMenu +
                 '}';
     }
 }

--- a/engine/src/main/resources/liquibase/changeSetPort.xml
+++ b/engine/src/main/resources/liquibase/changeSetPort.xml
@@ -14,7 +14,7 @@
     <include file="port/00000000000002_schemaPort.xml" relativeToChangelogFile="true" />
 
     <changeSet id="00000000000001_dataPort_restore" author="entando" context="restore" />
-    
+
     <include file="port/20221004100000_messages_system.xml" relativeToChangelogFile="true" />
 
     <include file="port/20230119000000_freemarker_for_parallel.xml" relativeToChangelogFile="true" />
@@ -22,5 +22,8 @@
     <include file="port/20230224000000_default_profile_roles.xml" relativeToChangelogFile="true" />
 
     <include file="port/20230308000000_legacy_api_refactoring.xml" relativeToChangelogFile="true" />
+
+    <include file="port/20230407000000_disable_content_menu.xml" relativeToChangelogFile="true" />
+
 
 </databaseChangeLog>

--- a/engine/src/main/resources/liquibase/port/20230407000000_disable_content_menu.xml
+++ b/engine/src/main/resources/liquibase/port/20230407000000_disable_content_menu.xml
@@ -1,0 +1,17 @@
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd
+                        http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.4.xsd">
+
+    <changeSet id="20230407000000_disable_content_menu" author="entando" context="production">
+
+        <addColumn tableName="userpreferences">
+            <column name="disablecontentmenu"
+                type="smallint" />
+        </addColumn>
+
+    </changeSet>
+
+</databaseChangeLog>

--- a/engine/src/main/resources/liquibase/port/20230407000000_disable_content_menu.xml
+++ b/engine/src/main/resources/liquibase/port/20230407000000_disable_content_menu.xml
@@ -5,7 +5,7 @@
     xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd
                         http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.4.xsd">
 
-    <changeSet id="20230407000000_disable_content_menu" author="entando" context="production">
+    <changeSet id="20230407000000_disable_content_menu" author="entando">
 
         <addColumn tableName="userpreferences">
             <column name="disablecontentmenu"

--- a/engine/src/test/java/org/entando/entando/web/userpreferences/10_PUT_user_preferences.json
+++ b/engine/src/test/java/org/entando/entando/web/userpreferences/10_PUT_user_preferences.json
@@ -1,0 +1,3 @@
+{
+    "disableContentMenu": true
+}

--- a/engine/src/test/java/org/entando/entando/web/userpreferences/11_PUT_user_preferences.json
+++ b/engine/src/test/java/org/entando/entando/web/userpreferences/11_PUT_user_preferences.json
@@ -1,0 +1,3 @@
+{
+    "disableContentMenu": false
+}

--- a/engine/src/test/java/org/entando/entando/web/userpreferences/2_PUT_user_preferences.json
+++ b/engine/src/test/java/org/entando/entando/web/userpreferences/2_PUT_user_preferences.json
@@ -20,5 +20,6 @@
     "defaultWidgetJoinGroups": [
         "group5",
         "group9"
-    ]
+    ],
+    "disableContentMenu": true
 }

--- a/engine/src/test/java/org/entando/entando/web/userpreferences/UserPreferencesControllerIntegrationTest.java
+++ b/engine/src/test/java/org/entando/entando/web/userpreferences/UserPreferencesControllerIntegrationTest.java
@@ -200,7 +200,8 @@ class UserPreferencesControllerIntegrationTest extends AbstractControllerIntegra
                     .andExpect(jsonPath("$.payload.defaultContentOwnerGroup", Matchers.isEmptyOrNullString()))
                     .andExpect(jsonPath("$.payload.defaultContentJoinGroups", Matchers.isEmptyOrNullString()))
                     .andExpect(jsonPath("$.payload.defaultWidgetOwnerGroup", Matchers.isEmptyOrNullString()))
-                    .andExpect(jsonPath("$.payload.defaultWidgetJoinGroups", Matchers.isEmptyOrNullString()));
+                    .andExpect(jsonPath("$.payload.defaultWidgetJoinGroups", Matchers.isEmptyOrNullString()))
+                    .andExpect(jsonPath("$.payload.disableContentMenu", Matchers.is(false)));
 
             InputStream file = this.getClass().getResourceAsStream("2_PUT_user_preferences.json");
             String bodyRequest = FileTextReader.getText(file);
@@ -230,7 +231,8 @@ class UserPreferencesControllerIntegrationTest extends AbstractControllerIntegra
                     .andExpect(jsonPath("$.payload.defaultWidgetOwnerGroup", Matchers.is("group2")))
                     .andExpect(jsonPath("$.payload.defaultWidgetJoinGroups.size()", Matchers.is(2)))
                     .andExpect(jsonPath("$.payload.defaultWidgetJoinGroups[0]", Matchers.is("group5")))
-                    .andExpect(jsonPath("$.payload.defaultWidgetJoinGroups[1]", Matchers.is("group9")));
+                    .andExpect(jsonPath("$.payload.defaultWidgetJoinGroups[1]", Matchers.is("group9")))
+                    .andExpect(jsonPath("$.payload.disableContentMenu", Matchers.is(true)));
 
             mockMvc.perform(
                     get("/userPreferences/{username}", username)
@@ -256,7 +258,8 @@ class UserPreferencesControllerIntegrationTest extends AbstractControllerIntegra
                     .andExpect(jsonPath("$.payload.defaultWidgetOwnerGroup", Matchers.is("group2")))
                     .andExpect(jsonPath("$.payload.defaultWidgetJoinGroups.size()", Matchers.is(2)))
                     .andExpect(jsonPath("$.payload.defaultWidgetJoinGroups[0]", Matchers.is("group5")))
-                    .andExpect(jsonPath("$.payload.defaultWidgetJoinGroups[1]", Matchers.is("group9")));
+                    .andExpect(jsonPath("$.payload.defaultWidgetJoinGroups[1]", Matchers.is("group9")))
+                    .andExpect(jsonPath("$.payload.disableContentMenu", Matchers.is(true)));
 
             file = this.getClass().getResourceAsStream("9_PUT_user_preferences.json");
             bodyRequest = FileTextReader.getText(file);
@@ -461,6 +464,58 @@ class UserPreferencesControllerIntegrationTest extends AbstractControllerIntegra
                     .andExpect(jsonPath("$.payload.wizard", Matchers.is(true)))
                     .andExpect(jsonPath("$.payload.loadOnPageSelect", Matchers.is(true)))
                     .andExpect(jsonPath("$.payload.translationWarning", Matchers.is(true)));
+
+            file = this.getClass().getResourceAsStream("10_PUT_user_preferences.json");
+            bodyRequest = FileTextReader.getText(file);
+
+            mockMvc.perform(
+                            put("/userPreferences/{username}", username)
+                                            .content(bodyRequest)
+                                            .contentType(MediaType.APPLICATION_JSON_VALUE)
+                                            .header("Authorization", "Bearer " + accessToken))
+                            .andDo(resultPrint())
+                            .andExpect(status().isOk())
+                            .andExpect(jsonPath("$.payload.wizard", Matchers.is(true)))
+                            .andExpect(jsonPath("$.payload.loadOnPageSelect", Matchers.is(true)))
+                            .andExpect(jsonPath("$.payload.translationWarning", Matchers.is(true)))
+                            .andExpect(jsonPath("$.payload.disableContentMenu", Matchers.is(true)));
+
+            mockMvc.perform(
+                            get("/userPreferences/{username}", username)
+                                            .contentType(MediaType.APPLICATION_JSON_VALUE)
+                                            .header("Authorization", "Bearer " + accessToken))
+                            .andDo(resultPrint())
+                            .andExpect(status().isOk())
+                            .andExpect(jsonPath("$.payload.wizard", Matchers.is(true)))
+                            .andExpect(jsonPath("$.payload.loadOnPageSelect", Matchers.is(true)))
+                            .andExpect(jsonPath("$.payload.translationWarning", Matchers.is(true)))
+                            .andExpect(jsonPath("$.payload.disableContentMenu", Matchers.is(true)));
+
+            file = this.getClass().getResourceAsStream("11_PUT_user_preferences.json");
+            bodyRequest = FileTextReader.getText(file);
+
+            mockMvc.perform(
+                            put("/userPreferences/{username}", username)
+                                            .content(bodyRequest)
+                                            .contentType(MediaType.APPLICATION_JSON_VALUE)
+                                            .header("Authorization", "Bearer " + accessToken))
+                            .andDo(resultPrint())
+                            .andExpect(status().isOk())
+                            .andExpect(jsonPath("$.payload.wizard", Matchers.is(true)))
+                            .andExpect(jsonPath("$.payload.loadOnPageSelect", Matchers.is(true)))
+                            .andExpect(jsonPath("$.payload.translationWarning", Matchers.is(true)))
+                            .andExpect(jsonPath("$.payload.disableContentMenu", Matchers.is(false)));
+
+            mockMvc.perform(
+                            get("/userPreferences/{username}", username)
+                                            .contentType(MediaType.APPLICATION_JSON_VALUE)
+                                            .header("Authorization", "Bearer " + accessToken))
+                            .andDo(resultPrint())
+                            .andExpect(status().isOk())
+                            .andExpect(jsonPath("$.payload.wizard", Matchers.is(true)))
+                            .andExpect(jsonPath("$.payload.loadOnPageSelect", Matchers.is(true)))
+                            .andExpect(jsonPath("$.payload.translationWarning", Matchers.is(true)))
+                            .andExpect(jsonPath("$.payload.disableContentMenu", Matchers.is(false)));
         } finally {
             this.userManager.removeUser(username);
             this.userPreferencesManager.deleteUserPreferences(username);


### PR DESCRIPTION
Add the `disableContentMenu` boolean property to `userPreferences` api.

Liquibase changelog to create the new column is provided but I've some dubts about the positioning of the changelog file itself. I put it in the `engine` module because that's were the schema is created. Should I have put in the `webapp` module? Note that the changelog has no data, just the column creation with `null` value.