### PR TITLE
ENG-5496 Fixing org.springframework:spring-web vulnerabilities

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
         <test.database.port.url>jdbc:derby:memory:testPort;create=true</test.database.port.url>
         <test.database.serv.url>jdbc:derby:memory:testServ;create=true</test.database.serv.url>
         <!--dependency versions-->
-        <spring.version>5.3.27</spring.version>
+        <spring.version>5.3.33</spring.version>
         <springsecurity.version>5.5.7</springsecurity.version>
         <springsecurityoauth2.version>2.5.2.RELEASE</springsecurityoauth2.version>
         <struts2.version>2.5.31</struts2.version>


### PR DESCRIPTION
Upgrade org.springframework:spring-web from version 5.3.27 to 5.3.33 This will fix the following vulnerabilities:

CVE-2024-22259: https://security.snyk.io/vuln/SNYK-JAVA-ORGSPRINGFRAMEWORK-6444790
CVE-2024-22243: https://security.snyk.io/vuln/SNYK-JAVA-ORGSPRINGFRAMEWORK-6261586