### PR TITLE
ENG-5497 Fixing struts vulnerabilities

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
         <spring.version>5.3.27</spring.version>
         <springsecurity.version>5.5.7</springsecurity.version>
         <springsecurityoauth2.version>2.5.2.RELEASE</springsecurityoauth2.version>
-        <struts2.version>2.5.31</struts2.version>
+        <struts2.version>2.5.33</struts2.version>
         <jackson.version>2.12.7</jackson.version>
         <jackson-databind.version>2.12.7.1</jackson-databind.version>
         <hibernate-validator-version>6.0.20.Final</hibernate-validator-version>


### PR DESCRIPTION
Upgrade org.apache.struts:struts2-core from version 2.5.31 to 2.5.33 This will fix the following vulnerabilities:

CVE-2023-41835: https://security.snyk.io/vuln/SNYK-JAVA-ORGAPACHESTRUTS-6100744
CVE-2023-50164: https://security.snyk.io/vuln/SNYK-JAVA-ORGAPACHESTRUTS-6102825