### PR TITLE
ENG-5499 Fixing spring-security-core vulnerability

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@
         <test.database.serv.url>jdbc:derby:memory:testServ;create=true</test.database.serv.url>
         <!--dependency versions-->
         <spring.version>5.3.27</spring.version>
-        <springsecurity.version>5.5.12</springsecurity.version>
+        <springsecurity.version>5.7.12</springsecurity.version>
         <springsecurityoauth2.version>2.5.2.RELEASE</springsecurityoauth2.version>
         <struts2.version>2.5.31</struts2.version>
         <jackson.version>2.12.7</jackson.version>

--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@
         <test.database.serv.url>jdbc:derby:memory:testServ;create=true</test.database.serv.url>
         <!--dependency versions-->
         <spring.version>5.3.27</spring.version>
-        <springsecurity.version>5.5.7</springsecurity.version>
+        <springsecurity.version>5.5.12</springsecurity.version>
         <springsecurityoauth2.version>2.5.2.RELEASE</springsecurityoauth2.version>
         <struts2.version>2.5.31</struts2.version>
         <jackson.version>2.12.7</jackson.version>


### PR DESCRIPTION
Upgrade org.springframework.security:spring-security-core from version 5.5.7 to 5.7.12 This will fix the following vulnerabilities:

CVE-2024-22257: https://security.snyk.io/vuln/SNYK-JAVA-ORGSPRINGFRAMEWORKSECURITY-6457293