### PR TITLE
ENG-5502 Fixing org.apache.commons:commons-compress vulnerabilities

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -167,7 +167,7 @@
         <stax-ex.version>2.0.1</stax-ex.version>
         <jaxb-api.version>2.3.1</jaxb-api.version>
         <activation.version>1.1.1</activation.version>
-        <commons-compress.version>1.21</commons-compress.version>
+        <commons-compress.version>1.26.0</commons-compress.version>
         <spring-data-redis.version>2.1.9.RELEASE</spring-data-redis.version>
         <spring-session-data-redis.version>2.7.0</spring-session-data-redis.version>
         <lettuce-core.version>6.1.5.RELEASE</lettuce-core.version>


### PR DESCRIPTION
This will fix the following vulnerabilities:

CVE-2024-26308: https://security.snyk.io/vuln/SNYK-JAVA-ORGAPACHECOMMONS-6254297
CVE-2024-25710: https://security.snyk.io/vuln/SNYK-JAVA-ORGAPACHECOMMONS-6254296