### PR TITLE
ESB-245 - Add root page protection and reorganize page utility endpoints

### DIFF
--- a/engine/src/main/java/org/entando/entando/aps/system/services/page/IPageService.java
+++ b/engine/src/main/java/org/entando/entando/aps/system/services/page/IPageService.java
@@ -48,6 +48,12 @@ public interface IPageService extends IComponentUsageService {
 
     PageDto getPage(String pageCode, String status);
 
+    PageDto getRootPage(String status, UserDetails user);
+
+    PageDto getRootPage(String status);
+
+    String getRootPageCode();
+
     PageDto addPage(PageRequest pageRequest);
 
     void removePage(String pageName);

--- a/engine/src/main/java/org/entando/entando/aps/system/services/page/PageService.java
+++ b/engine/src/main/java/org/entando/entando/aps/system/services/page/PageService.java
@@ -273,7 +273,10 @@ public class PageService implements IComponentExistsService, IPageService,
     @Override
     public String getRootPageCode() {
         IPage root = this.getPageManager().getDraftRoot();
-        return root != null ? root.getCode() : "homepage";
+        if (root == null) {
+            throw new ResourceNotFoundException(ERRCODE_PAGE_NOT_FOUND, "page", "RootPage");
+        }
+        return  root.getCode();
     }
 
     private String getUrlToken(String token) {

--- a/engine/src/main/java/org/entando/entando/aps/system/services/page/PageService.java
+++ b/engine/src/main/java/org/entando/entando/aps/system/services/page/PageService.java
@@ -241,6 +241,41 @@ public class PageService implements IComponentExistsService, IPageService,
         return pageDto;
     }
 
+    @Override
+    public PageDto getRootPage(String status, UserDetails user) {
+        PageDto pageDto = this.getRootPage(status);
+        return this.loadVirtualChildren(pageDto, user);
+    }
+
+    @Override
+    public PageDto getRootPage(String status) {
+        IPage page;
+        switch (status) {
+            case STATUS_ONLINE:
+                page = this.getPageManager().getOnlineRoot();
+                break;
+            case STATUS_DRAFT:
+            default:
+                page = this.getPageManager().getDraftRoot();
+                break;
+        }
+        if (null == page) {
+            throw new RestServerError("Root page not found");
+        }
+        PageDto pageDto = this.getDtoBuilder().convert(page);
+        String token = this.getPageTokenManager().encrypt(page.getCode());
+        String urlToken = getUrlToken(token);
+        pageDto.setToken(urlToken);
+        pageDto.setReferences(this.getReferencesInfo(page));
+        return pageDto;
+    }
+
+    @Override
+    public String getRootPageCode() {
+        IPage root = this.getPageManager().getDraftRoot();
+        return root != null ? root.getCode() : "homepage";
+    }
+
     private String getUrlToken(String token) {
         try {
             return URLEncoder.encode(token, "UTF-8");
@@ -377,6 +412,12 @@ public class PageService implements IComponentExistsService, IPageService,
                 this.getPageManager().setPageOnline(pageCode);
                 newPage = this.getPageManager().getOnlinePage(pageCode);
             } else if (status.equals(STATUS_DRAFT)) {
+                IPage rootPage = this.getPageManager().getOnlineRoot();
+                if (rootPage != null && rootPage.getCode().equals(pageCode)) {
+                    bindingResult.reject(PageValidator.ERRCODE_ROOT_PAGE,
+                            new String[]{pageCode}, "page.status.root.unpublish");
+                    throw new ValidationGenericException(bindingResult);
+                }
                 String[] childCodes = currentPage.getChildrenCodes();
                 for (String childCode : childCodes) {
                     IPage publicChild = this.getPageManager().getOnlinePage(childCode);

--- a/engine/src/main/java/org/entando/entando/web/page/PageController.java
+++ b/engine/src/main/java/org/entando/entando/web/page/PageController.java
@@ -112,14 +112,18 @@ public class PageController {
     @RequestMapping(value = "/pages", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<RestResponse<List<PageDto>, Map<String, Object>>> getPages(
             @RequestAttribute("user") UserDetails user,
-            @RequestParam(value = "parentCode", required = false, defaultValue = "homepage") String parentCode,
+            @RequestParam(value = "parentCode", required = false) String parentCode,
             @RequestParam(value = "forLinkingToOwnerGroup", required = false) String forLinkingToOwnerGroup,
             @RequestParam(value = "forLinkingToExtraGroups", required = false) String forLinkingToExtraGroups) {
+        if (parentCode == null || parentCode.isEmpty()) {
+            parentCode = this.getPageService().getRootPageCode();
+        }
         logger.debug("getting page tree for parent {} ({}|{})", parentCode,
                 forLinkingToOwnerGroup, forLinkingToExtraGroups);
 
+        String rootPageCode = this.getPageService().getRootPageCode();
         boolean editableParent = this.getAuthorizationService().canEdit(user, parentCode);
-        if (!editableParent && !parentCode.equals("homepage")) {
+        if (!editableParent && !parentCode.equals(rootPageCode)) {
             throw new ResourcePermissionsException(user.getUsername(), parentCode);
         }
 
@@ -145,7 +149,7 @@ public class PageController {
     }
 
     @RestAccessControl(permission = Permission.MANAGE_PAGES)
-    @RequestMapping(value = "/pages/search", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
+    @RequestMapping(value = "/pages/utils/search", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<PagedRestResponse<PageDto>> getPages(@RequestAttribute("user") UserDetails user, PageSearchRequest searchRequest) {
         logger.debug("getting page list with request {}", searchRequest);
         this.getPageValidator().validateRestListRequest(searchRequest, PageDto.class);
@@ -155,7 +159,7 @@ public class PageController {
     }
 
     @RestAccessControl(permission = Permission.MANAGE_PAGES)
-    @RequestMapping(value = "/pages/search/group/free", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
+    @RequestMapping(value = "/pages/utils/search/group/free", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<PagedRestResponse<PageDto>> getFreeOnlinePages(@RequestAttribute("user") UserDetails user, RestListRequest restListRequest) {
         logger.debug("getting free pages list with request {}", restListRequest);
         this.getPageValidator().validateRestListRequest(restListRequest, PageDto.class);
@@ -164,12 +168,24 @@ public class PageController {
     }
 
     @RestAccessControl(permission = Permission.MANAGE_PAGES)
-    @RequestMapping(value = "/pages/viewpages", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
+    @RequestMapping(value = "/pages/utils/viewpages", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<SimpleRestResponse<List<PageDto>>> listViewPages() {
         logger.debug("REST request - content type list view pages");
 
         return ResponseEntity.ok(
                 new SimpleRestResponse<>(pageService.listViewPages()));
+    }
+
+    @RestAccessControl(permission = Permission.MANAGE_PAGES)
+    @RequestMapping(value = "/pages/utils/root", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<RestResponse<PageDto, Map<String, String>>> getRootPage(
+            @RequestAttribute("user") UserDetails user,
+            @RequestParam(value = "status", required = false, defaultValue = IPageService.STATUS_DRAFT) String status) {
+        logger.debug("getting root page");
+        PageDto page = this.getPageService().getRootPage(status, user);
+        Map<String, String> metadata = new HashMap<>();
+        metadata.put("status", status);
+        return new ResponseEntity<>(new RestResponse<>(page, metadata), HttpStatus.OK);
     }
 
     @RestAccessControl(permission = Permission.MANAGE_PAGES)
@@ -348,6 +364,10 @@ public class PageController {
             throw new ValidationGenericException(bindingResult);
         }
         //business validations
+        getPageValidator().validateRootPage(pageCode, bindingResult);
+        if (bindingResult.hasErrors()) {
+            throw new ValidationGenericException(bindingResult);
+        }
         getPageValidator().validateOnlinePage(pageCode, bindingResult);
         if (bindingResult.hasErrors()) {
             throw new ValidationGenericException(bindingResult);

--- a/engine/src/main/java/org/entando/entando/web/page/PageController.java
+++ b/engine/src/main/java/org/entando/entando/web/page/PageController.java
@@ -115,13 +115,13 @@ public class PageController {
             @RequestParam(value = "parentCode", required = false) String parentCode,
             @RequestParam(value = "forLinkingToOwnerGroup", required = false) String forLinkingToOwnerGroup,
             @RequestParam(value = "forLinkingToExtraGroups", required = false) String forLinkingToExtraGroups) {
+        String rootPageCode = this.getPageService().getRootPageCode();
         if (parentCode == null || parentCode.isEmpty()) {
-            parentCode = this.getPageService().getRootPageCode();
+            parentCode = rootPageCode;
         }
         logger.debug("getting page tree for parent {} ({}|{})", parentCode,
                 forLinkingToOwnerGroup, forLinkingToExtraGroups);
 
-        String rootPageCode = this.getPageService().getRootPageCode();
         boolean editableParent = this.getAuthorizationService().canEdit(user, parentCode);
         if (!editableParent && !parentCode.equals(rootPageCode)) {
             throw new ResourcePermissionsException(user.getUsername(), parentCode);

--- a/engine/src/main/java/org/entando/entando/web/page/validator/PageValidator.java
+++ b/engine/src/main/java/org/entando/entando/web/page/validator/PageValidator.java
@@ -56,6 +56,7 @@ public class PageValidator extends AbstractPaginationValidator {
     public static final String ERRCODE_PAGE_WITH_PUBLIC_CHILD = "8";
     public static final String ERRCODE_PAGE_WITH_NO_PUBLIC_PARENT = "9";
     public static final String ERRCODE_PAGE_INVALID_TITLE = "12";
+    public static final String ERRCODE_ROOT_PAGE = "13";
 
     private final org.slf4j.Logger logger = EntLogFactory.getSanitizedLogger(getClass());
 
@@ -120,6 +121,13 @@ public class PageValidator extends AbstractPaginationValidator {
         IPage page = getDraftPage(pageCode);
         if (page != null && page.getChildrenCodes() != null && page.getChildrenCodes().length > 0) {
             errors.reject(ERRCODE_PAGE_HAS_CHILDREN, new String[]{pageCode}, "page.delete.children");
+        }
+    }
+
+    public void validateRootPage(String pageCode, Errors errors) {
+        IPage root = this.getPageManager().getDraftRoot();
+        if (root != null && root.getCode().equals(pageCode)) {
+            errors.reject(ERRCODE_ROOT_PAGE, new String[]{pageCode}, "page.delete.root");
         }
     }
 

--- a/engine/src/main/resources/rest/messages.properties
+++ b/engine/src/main/resources/rest/messages.properties
@@ -86,6 +86,8 @@ page.status.invalid.draft.ref=draft page has references
 page.status.parent.unpublished=The page ''{0}'' can''t be published because the parent page ''{1}'' is not public
 page.status.publicChild=The page ''{0}'' can''t be unpublished because it has public children
 page.widgetconfig.notoverridable=The widget configuration is not overridable
+page.delete.root=The root page ''{0}'' cannot be deleted
+page.status.root.unpublish=The root page ''{0}'' cannot be unpublished
 page.title.notBlank=Page title for language ''{0}'' is required
 invalidParameter.framedId=the URI parameter ''{0}'' is not valid
 

--- a/engine/src/test/java/org/entando/entando/web/page/PageControllerIntegrationTest.java
+++ b/engine/src/test/java/org/entando/entando/web/page/PageControllerIntegrationTest.java
@@ -204,7 +204,7 @@ class PageControllerIntegrationTest extends AbstractControllerIntegrationTest {
                 .build();
         String accessToken = mockOAuthInterceptor(user);
         ResultActions result = mockMvc
-                .perform(get("/pages/search")
+                .perform(get("/pages/utils/search")
                         .param("pageSize", "5")
                         .param("pageCodeToken", "pagin")
                         .header("Authorization", "Bearer " + accessToken));
@@ -220,7 +220,7 @@ class PageControllerIntegrationTest extends AbstractControllerIntegrationTest {
                 .build();
         String accessToken = mockOAuthInterceptor(user);
         ResultActions result = mockMvc
-                .perform(get("/pages/search")
+                .perform(get("/pages/utils/search")
                         .param("pageSize", "20")
                         .param("title", "errore")
                         .header("Authorization", "Bearer " + accessToken));
@@ -230,7 +230,7 @@ class PageControllerIntegrationTest extends AbstractControllerIntegrationTest {
         result.andExpect(jsonPath("$.payload[0].code", is("errorpage")));
 
         result = mockMvc
-                .perform(get("/pages/search")
+                .perform(get("/pages/utils/search")
                         .param("pageSize", "20")
                         .param("title", "iniziale")
                         .header("Authorization", "Bearer " + accessToken));
@@ -240,7 +240,7 @@ class PageControllerIntegrationTest extends AbstractControllerIntegrationTest {
         result.andExpect(jsonPath("$.payload[0].code", is("homepage")));
 
         result = mockMvc
-                .perform(get("/pages/search")
+                .perform(get("/pages/utils/search")
                         .param("pageSize", "20")
                         .param("title", "di")
                         .header("Authorization", "Bearer " + accessToken));
@@ -250,7 +250,7 @@ class PageControllerIntegrationTest extends AbstractControllerIntegrationTest {
         result.andExpect(jsonPath("$.payload[0].code", is("errorpage")));
 
         result = mockMvc
-                .perform(get("/pages/search")
+                .perform(get("/pages/utils/search")
                         .param("pageSize", "20")
                         .param("title", "start")
                         .header("Authorization", "Bearer " + accessToken));
@@ -421,7 +421,7 @@ class PageControllerIntegrationTest extends AbstractControllerIntegrationTest {
                 .build();
         String accessToken = mockOAuthInterceptor(user);
         ResultActions result = mockMvc
-                .perform(get("/pages/search/group/free")
+                .perform(get("/pages/utils/search/group/free")
                         .param("pageSize", "50")
                         .header("Authorization", "Bearer " + accessToken));
         result.andExpect(status().isOk());
@@ -1872,7 +1872,7 @@ class PageControllerIntegrationTest extends AbstractControllerIntegrationTest {
 
 
     private ResultActions performListViewPages(String accessToken) throws Exception {
-        return mockMvc.perform(get("/pages/viewpages")
+        return mockMvc.perform(get("/pages/utils/viewpages")
                 .header("Authorization", "Bearer " + accessToken));
     }
 
@@ -2246,7 +2246,7 @@ class PageControllerIntegrationTest extends AbstractControllerIntegrationTest {
                 .andExpect(status().isOk());
 
         // search
-        mockMvc.perform(get("/pages/search")
+        mockMvc.perform(get("/pages/utils/search")
                         .param("sort", "code")
                         .param("direction", "ASC")
                         .param("pageCodeToken", "homepage")

--- a/engine/src/test/java/org/entando/entando/web/page/PageControllerTest.java
+++ b/engine/src/test/java/org/entando/entando/web/page/PageControllerTest.java
@@ -43,6 +43,7 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import org.entando.entando.aps.system.services.page.IPageService;
 import org.entando.entando.aps.system.services.page.PageAuthorizationService;
 import org.entando.entando.aps.system.services.page.PageService;
 import org.entando.entando.aps.system.services.page.model.PageDto;
@@ -219,6 +220,7 @@ class PageControllerTest extends AbstractControllerTest {
         List<PageDto> mockResult = List.of(page1);
 
         Mockito.when(pageService.getPagesTree(eq("homepage"), any())).thenReturn(mockResult);
+        Mockito.when(pageService.getRootPageCode()).thenReturn("homepage");
         Mockito.when(authorizationService.canEdit(any(UserDetails.class), eq("homepage"))).thenReturn(false);
 
         ResultActions result = mockMvc.perform(
@@ -912,6 +914,7 @@ class PageControllerTest extends AbstractControllerTest {
         UserDetails user = new OAuth2TestUtils.UserBuilder("jack_bauer", "0x24").grantedToRoleAdmin().build();
         String accessToken = mockOAuthInterceptor(user);
 
+        when(pageService.getRootPageCode()).thenReturn("homepage");
         when(pageService.getPagesTree(eq("homepage"), any())).thenReturn(List.of());
 
         mockMvc.perform(get("/pages")
@@ -926,6 +929,44 @@ class PageControllerTest extends AbstractControllerTest {
         List<PageDto> result = mapper.readValue(json, new TypeReference<List<PageDto>>() {
         });
         return result;
+    }
+
+    @Test
+    void shouldGetRootPage() throws Exception {
+        UserDetails user = new OAuth2TestUtils.UserBuilder("jack_bauer", "0x24")
+                .withAuthorization(Group.FREE_GROUP_NAME, "managePages", Permission.MANAGE_PAGES)
+                .build();
+        String accessToken = mockOAuthInterceptor(user);
+
+        PageDto rootPageDto = new PageDto();
+        rootPageDto.setCode("home");
+
+        when(pageService.getRootPage(eq(IPageService.STATUS_DRAFT), any(UserDetails.class))).thenReturn(rootPageDto);
+
+        mockMvc.perform(get("/pages/utils/root")
+                        .header("Authorization", "Bearer " + accessToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.payload.code", is("home")))
+                .andExpect(jsonPath("$.metaData.status", is("draft")));
+    }
+
+    @Test
+    void shouldValidateDeleteRootPage() throws Exception {
+        UserDetails user = new OAuth2TestUtils.UserBuilder("jack_bauer", "0x24").grantedToRoleAdmin().build();
+        String accessToken = mockOAuthInterceptor(user);
+
+        Page rootPage = new Page();
+        rootPage.setCode("homepage");
+        when(authorizationService.canEdit(any(UserDetails.class), any(String.class))).thenReturn(true);
+        when(this.controller.getPageValidator().getPageManager().getDraftRoot()).thenReturn(rootPage);
+
+        ResultActions result = mockMvc.perform(
+                delete("/pages/{pageCode}", "homepage")
+                        .header("Authorization", "Bearer " + accessToken));
+
+        result.andExpect(status().isBadRequest());
+        result.andExpect(jsonPath("$.errors", hasSize(1)));
+        result.andExpect(jsonPath("$.errors[0].code", is(PageValidator.ERRCODE_ROOT_PAGE)));
     }
 
     private class PageM extends Page {

--- a/engine/src/test/java/org/entando/entando/web/page/validator/PageValidatorTest.java
+++ b/engine/src/test/java/org/entando/entando/web/page/validator/PageValidatorTest.java
@@ -88,6 +88,28 @@ class PageValidatorTest {
         Assertions.assertTrue(errors.hasErrors());
     }
 
+    @Test
+    void validateRootPageShouldRejectRootPageDeletion() {
+        IPage rootPage = Mockito.mock(IPage.class);
+        Mockito.when(rootPage.getCode()).thenReturn("homepage");
+        Mockito.when(pageManager.getDraftRoot()).thenReturn(rootPage);
+
+        BindingResult errors = (new DataBinder(new Object())).getBindingResult();
+        validator.validateRootPage("homepage", errors);
+        Assertions.assertTrue(errors.hasErrors());
+    }
+
+    @Test
+    void validateRootPageShouldAllowNonRootPageDeletion() {
+        IPage rootPage = Mockito.mock(IPage.class);
+        Mockito.when(rootPage.getCode()).thenReturn("homepage");
+        Mockito.when(pageManager.getDraftRoot()).thenReturn(rootPage);
+
+        BindingResult errors = (new DataBinder(new Object())).getBindingResult();
+        validator.validateRootPage("some_other_page", errors);
+        Assertions.assertFalse(errors.hasErrors());
+    }
+
     private UserDetails getMockUser(){
         User u = new User();
         u.setUsername("mockUser");


### PR DESCRIPTION
  - Prevent deletion and unpublishing of the root page with proper validation
  - Add GET /pages/utils/root endpoint to retrieve root page dynamically
  - Replace hardcoded "homepage" parentCode with dynamic root page code lookup
  
  BREAKINGCHANGES :
  - Move search/viewpages endpoints under /pages/utils/ path