### PR TITLE
ESB-1154 Lucene fix attack surface

### DIFF
--- a/solr-plugin/src/main/java/org/entando/entando/plugins/jpsolr/aps/system/solr/SearcherDAO.java
+++ b/solr-plugin/src/main/java/org/entando/entando/plugins/jpsolr/aps/system/solr/SearcherDAO.java
@@ -30,6 +30,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Pattern;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -64,6 +65,12 @@ import org.entando.entando.plugins.jpsolr.aps.system.solr.model.SolrSearchEngine
  */
 @Slf4j
 public class SearcherDAO implements ISolrSearcherDAO {
+
+    // Allowlist for Lucene/Solr field names: only alphanumeric and underscore.
+    // Parentheses, spaces, operators (AND/OR/NOT), and other Lucene meta-characters
+    // in a field name break the serialized query string produced by BooleanQuery.toString()
+    // and are the root of the Lucene query injection vulnerability.
+    private static final Pattern VALID_FIELD_KEY = Pattern.compile("[a-zA-Z0-9_]+");
 
     private ITreeNodeManager treeNodeManager;
     private ILangManager langManager;
@@ -541,6 +548,10 @@ public class SearcherDAO implements ISolrSearcherDAO {
 
     protected String getFilterKey(SearchEngineFilter<?> filter) {
         String key = filter.getKey().replace(":", "_");
+        if (!VALID_FIELD_KEY.matcher(key).matches()) {
+            throw new IllegalArgumentException(
+                    "Rejected Solr field key with unsafe characters: '" + key + "'");
+        }
         if (filter.isFullTextSearch()) {
             return key;
         }
@@ -548,7 +559,12 @@ public class SearcherDAO implements ISolrSearcherDAO {
             String insertedLangCode = filter.getLangCode();
             String langCode = (StringUtils.isBlank(insertedLangCode)) ? this.getLangManager().getDefaultLang().getCode()
                     : insertedLangCode;
-            key = langCode.toLowerCase() + "_" + key;
+            String normalizedLang = langCode.toLowerCase();
+            if (!VALID_FIELD_KEY.matcher(normalizedLang).matches()) {
+                throw new IllegalArgumentException(
+                        "Rejected Solr lang code with unsafe characters: '" + normalizedLang + "'");
+            }
+            key = normalizedLang + "_" + key;
         } else if (!key.startsWith(SolrFields.SOLR_FIELD_PREFIX)) {
             key = SolrFields.SOLR_FIELD_PREFIX + key;
         }

--- a/solr-plugin/src/test/java/org/entando/entando/plugins/jpsolr/aps/system/solr/SearcherDAOSpecialCharsTest.java
+++ b/solr-plugin/src/test/java/org/entando/entando/plugins/jpsolr/aps/system/solr/SearcherDAOSpecialCharsTest.java
@@ -21,6 +21,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * Special-character handling tests for SearcherDAO query building.
@@ -241,6 +242,100 @@ class SearcherDAOSpecialCharsTest {
 
         runAndAssert(filter,
                 "+(entity_key:\"foo:bar\" entity_key:\"baz+qux\") +(entity_group:free)");
+    }
+
+    // ------------------------------------------------------------------
+    // Field-key injection tests (CVE-class: Lucene query injection)
+    //
+    // User-controlled field names that contain Lucene/Solr meta-characters
+    // (parentheses, spaces, operators, local-params braces …) corrupt the
+    // query string produced by BooleanQuery.toString() and can break the
+    // group-based access-control filter.  All such inputs must be rejected
+    // with IllegalArgumentException before any Term object is constructed.
+    // ------------------------------------------------------------------
+
+    @Test
+    void shouldRejectFieldNameWithParenthesisAndOrOperator() {
+        // Simulates: filters[0].attribute = "foo) OR (*:*"
+        SolrSearchEngineFilter<String> filter =
+                new SolrSearchEngineFilter<>("foo) OR (*:*", false, "value");
+
+        assertThrows(IllegalArgumentException.class, () ->
+                searcherDAO.searchFacetedContents(new SearchEngineFilter[]{filter},
+                        new SearchEngineFilter[]{}, new ArrayList<>()));
+    }
+
+    @Test
+    void shouldRejectEntityAttrWithInjectedOperator() {
+        // Simulates: filters[0].entityAttr = "attr) OR (*:*"  (isAttributeFilter = true)
+        SolrSearchEngineFilter<String> filter =
+                new SolrSearchEngineFilter<>("attr) OR (*:*", true, "value");
+
+        assertThrows(IllegalArgumentException.class, () ->
+                searcherDAO.searchFacetedContents(new SearchEngineFilter[]{filter},
+                        new SearchEngineFilter[]{}, new ArrayList<>()));
+    }
+
+    @Test
+    void shouldRejectFieldNameWithSpaces() {
+        SolrSearchEngineFilter<String> filter =
+                new SolrSearchEngineFilter<>("valid AND malicious", false, "value");
+
+        assertThrows(IllegalArgumentException.class, () ->
+                searcherDAO.searchFacetedContents(new SearchEngineFilter[]{filter},
+                        new SearchEngineFilter[]{}, new ArrayList<>()));
+    }
+
+    @Test
+    void shouldRejectLangCodeUsedAsFullTextSearchKey() {
+        // Simulates: lang = "en) OR (*:*" passed as the full-text search field key.
+        // The filter key IS the lang code when fullTextSearch = true.
+        SolrSearchEngineFilter<String> filter =
+                new SolrSearchEngineFilter<>("en) OR (*:*", "search text",
+                        TextSearchOption.AT_LEAST_ONE_WORD);
+        filter.setFullTextSearch(true);
+
+        assertThrows(IllegalArgumentException.class, () ->
+                searcherDAO.searchFacetedContents(new SearchEngineFilter[]{filter},
+                        new SearchEngineFilter[]{}, new ArrayList<>()));
+    }
+
+    @Test
+    void shouldRejectInjectedLangCodePrefixOnAttributeFilter() {
+        // Simulates a crafted SolrSearchEngineFilter whose langCode (the prefix
+        // prepended to the field name for attribute filters) contains operators.
+        SolrSearchEngineFilter<String> filter =
+                new SolrSearchEngineFilter<>("key", true, "value");
+        filter.setLangCode("en) OR (*:*");
+
+        assertThrows(IllegalArgumentException.class, () ->
+                searcherDAO.searchFacetedContents(new SearchEngineFilter[]{filter},
+                        new SearchEngineFilter[]{}, new ArrayList<>()));
+    }
+
+    @Test
+    void shouldRejectFieldNameWithSolrLocalParamsBrace() {
+        // Simulates an attempt to inject Solr local params ({!...}) via field name.
+        SolrSearchEngineFilter<String> filter =
+                new SolrSearchEngineFilter<>("{!func}log(popularity)", false, "value");
+
+        assertThrows(IllegalArgumentException.class, () ->
+                searcherDAO.searchFacetedContents(new SearchEngineFilter[]{filter},
+                        new SearchEngineFilter[]{}, new ArrayList<>()));
+    }
+
+    @Test
+    void shouldRejectFieldNameInDoubleFilterArray() {
+        // Same injection via the searchFacetedContents(SearchEngineFilter[][] …) overload.
+        SolrSearchEngineFilter<String> filter =
+                new SolrSearchEngineFilter<>("foo) OR (*:*", false, "value");
+
+        SearchEngineFilter[][] doubleFilters =
+                new SearchEngineFilter[][]{{filter}};
+
+        assertThrows(IllegalArgumentException.class, () ->
+                searcherDAO.searchFacetedContents(doubleFilters,
+                        new SearchEngineFilter[]{}, new ArrayList<>()));
     }
 
     // ------------------------------------------------------------------


### PR DESCRIPTION
CVE-2019-17558 VelocityResponseWriter
CVE-2017-12629 XXE

## Lucene Query Injection → bypass dei controlli di accesso**

Il filtro di visibilità dei gruppi (`+(entity_group:free)`) viene applicato programmaticamente come clausola **MUST** all'interno della `BooleanQuery`. L'iniezione di parentesi nel nome di un campo altera il bilanciamento della stringa serializzata della query, consentendo al parser di Solr di ricostruire un albero di clausole differente, nel quale la restrizione sul gruppo non viene più applicata come previsto.

**Confermato: Injection del parametro di ordinamento (Sort Parameter Injection)**

Le chiavi dei campi utilizzate in `SolrQuery.addSort(fieldKey, order)` (derivate dai campi di ordinamento dei filtri) erano soggette alla medesima assenza di sanitizzazione, rendendo possibile l'iniezione nel parametro HTTP `sort` inviato a Solr.

**Non ottenibile: Remote Code Execution (RCE) a livello di sistema operativo tramite Solr Local Params**

I noti vettori di RCE di Solr (CVE-2019-17558 - VelocityResponseWriter e CVE-2017-12629 - XXE) richiedono che i local params (`{!...}`) siano presenti all'inizio della stringa del parametro `q`. Tuttavia, `BooleanQuery.toString()` genera sempre una stringa che inizia con `+`, `-` oppure `(`, rendendo impossibile posizionare i local params all'indice 0 attraverso questo percorso. Inoltre, il controller non inoltra parametri HTTP arbitrari a SolrJ (ad esempio `wt`, `v.template`, ecc.).

## Correzione

**File:** `solr-plugin/src/main/java/org/entando/entando/plugins/jpsolr/aps/system/solr/SearcherDAO.java`

È stata introdotta una rigorosa allowlist, applicata nel metodo `getFilterKey()`, che rappresenta il punto unico di controllo attraverso cui transitano tutti i nomi dei campi prima di essere utilizzati per la creazione degli oggetti `Term`.

```java
private static final Pattern VALID_FIELD_KEY = Pattern.compile("[a-zA-Z0-9_]+");
```

Sono stati aggiunti due controlli:

1. **Controllo sulla chiave del campo (Field-key guard)** – applicato dopo la chiamata a `replace(":", "_")`. Viene rifiutata qualsiasi chiave contenente caratteri diversi da `[a-zA-Z0-9_]`. Il controllo copre i campi `attribute`, `entityAttr` e `lang` (utilizzato come chiave per la ricerca full-text).

2. **Controllo sul prefisso della lingua (Lang-prefix guard)** – applicato al codice della lingua prima che venga anteposto ai nomi dei campi degli attributi utilizzati nei filtri. Questo elimina anche il percorso di injection ottenibile tramite un valore `langCode` appositamente costruito.

Entrambi i controlli generano una `IllegalArgumentException` in caso di violazione. Attualmente l'eccezione non viene gestita e si propaga fino al chiamante, producendo una risposta **HTTP 500**. Un possibile miglioramento futuro consiste nel gestire l'eccezione a livello di controller, restituendo invece un errore **HTTP 400 (Bad Request)**.
